### PR TITLE
Fix CORS headers missing on 500 Internal Server Errors

### DIFF
--- a/backend/common/middleware.py
+++ b/backend/common/middleware.py
@@ -1,5 +1,7 @@
 from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
 from fastapi import Request
+from backend.common.logging import get_logger
 
 class PathRewriteMiddleware(BaseHTTPMiddleware):
     """
@@ -16,3 +18,19 @@ class PathRewriteMiddleware(BaseHTTPMiddleware):
 
         response = await call_next(request)
         return response
+
+class ExceptionHandlingMiddleware(BaseHTTPMiddleware):
+    """
+    Middleware to catch unhandled exceptions and return a JSON response with 500 status code.
+    This ensures that CORS middleware can still add headers to the response.
+    """
+    async def dispatch(self, request: Request, call_next):
+        try:
+            return await call_next(request)
+        except Exception as e:
+            logger = get_logger("backend.middleware.exception")
+            logger.error(f"Unhandled exception: {str(e)}", exc_info=True)
+            return JSONResponse(
+                status_code=500,
+                content={"detail": "Internal Server Error"}
+            )

--- a/backend/main.py
+++ b/backend/main.py
@@ -7,7 +7,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from backend.common.middleware import PathRewriteMiddleware
+from backend.common.middleware import PathRewriteMiddleware, ExceptionHandlingMiddleware
 from backend.api.problems import router as problems_router
 from backend.api.sql import router as sql_router
 from backend.api.stats import router as stats_router
@@ -87,6 +87,10 @@ app = FastAPI(
 # PathRewriteMiddleware 등록 (CORS보다 먼저 등록하여 안쪽에 위치하게 함 -> CORS가 바깥쪽에서 먼저 실행됨)
 # 순서: Request -> CORS -> PathRewrite -> Router
 app.add_middleware(PathRewriteMiddleware)
+
+# Exception handling middleware - catch exceptions before they crash the server,
+# ensuring CORS headers are added by the outer CORS middleware.
+app.add_middleware(ExceptionHandlingMiddleware)
 
 # CORS 설정 - 환경별 분리
 # Cloud Run 도메인 및 Regex 정의 (환경 무관하게 참조 가능하도록)


### PR DESCRIPTION
Fixes an issue where 500 Internal Server Errors were missing CORS headers, causing the frontend to report a CORS policy violation instead of the actual server error. This was achieved by adding a middleware to catch exceptions and return a standard JSON response that the CORS middleware can process.

---
*PR created automatically by Jules for task [5447507024945446393](https://jules.google.com/task/5447507024945446393) started by @KnellBalm*

## Summary by Sourcery

Add global exception handling middleware to ensure 500 Internal Server Error responses include CORS headers and a consistent JSON error body.

Bug Fixes:
- Ensure 500 Internal Server Error responses include CORS headers so the frontend receives the actual server error instead of a CORS violation.

Enhancements:
- Introduce a central exception handling middleware that logs unhandled exceptions and returns a standardized JSON 500 error response.