### PR TITLE
Fix CORS issues and add Origin logging for debugging

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,6 +5,7 @@ PostgreSQL 연결이 필요한 테스트는 @pytest.mark.integration 마커 사�
 """
 import pytest
 import os
+from unittest import mock
 from datetime import date
 
 # 통합 테스트 마커
@@ -26,8 +27,11 @@ class TestConfigSettings:
     def test_db_config_loads(self):
         """config.db 모듈이 에러 없이 로드되어야 함"""
         from backend.config.db import PostgresEnv, get_duckdb_path
-        env = PostgresEnv()
-        assert env.dsn() is not None
+
+        # 다른 테스트에서 ENV를 production으로 설정할 수 있으므로 강제로 development로 설정
+        with mock.patch.dict(os.environ, {"ENV": "development"}):
+            env = PostgresEnv()
+            assert env.dsn() is not None
         assert get_duckdb_path() is not None
 
 


### PR DESCRIPTION
This PR addresses the reported CORS issue where the frontend (`us-central1` region) was blocked from accessing the backend.

Changes:
1.  **Observability**: Added `LogOriginMiddleware` to log the `Origin` header of incoming requests. This helps verify if the browser is sending the expected origin and if it matches the allowed list/regex in the production environment.
2.  **Configuration**: Refactored `backend/main.py` to ensure `cloud_origins` and `cloud_origin_regex` are correctly defined and applied. The regex `r"https://query-craft-frontend.*\.run\.app"` supports various regional subdomains.
3.  **Middleware Order**: Explicitly ordered middleware (LogOrigin -> CORS -> Exception -> PathRewrite) to ensure proper handling of headers and logging.

Tests:
- Verified locally with `tests/reproduce_cors.py` (created and then deleted).
- Ran existing tests `tests/test_cors_config.py` and `tests/test_auth.py` which passed.

---
*PR created automatically by Jules for task [1347566996273756232](https://jules.google.com/task/1347566996273756232) started by @KnellBalm*

## Summary by Sourcery

Clarify and harden CORS configuration while adding request origin logging for improved CORS debugging and error observability.

Bug Fixes:
- Correct CORS configuration and middleware ordering to ensure Cloud Run frontend origins are properly allowed in production and development environments.

Enhancements:
- Centralize Cloud Run origin and regex definitions for reuse across environments.
- Introduce middleware to log incoming request Origin headers, paths, and methods before CORS handling for easier debugging of CORS issues.
- Standardize middleware logging by using a shared backend.middleware logger for exception and origin logging.