### PR TITLE
fix(backend): Explicitly whitelist reported frontend origin in CORS config

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -101,8 +101,8 @@ app.add_middleware(ExceptionHandlingMiddleware)
 # Cloud Run 도메인 및 Regex 정의 (환경 무관하게 참조 가능하도록)
 cloud_origins = [
     "https://query-craft-frontend-53ngedkhia-uc.a.run.app",
-    "https://query-craft-frontend-758178119666.us-central1.run.app",
-    "https://query-craft-frontend-758178119666.a.run.app", # 추가
+    "https://query-craft-frontend-758178119666.us-central1.run.app",  # Reported issue origin
+    "https://query-craft-frontend-758178119666.a.run.app",
     "https://querycraft.run.app",  # 커스텀 도메인 예비
 ]
 # 좀 더 유연한 regex: query-craft-frontend로 시작하는 모든 .run.app 도메인 허용

--- a/tests/test_cors_config.py
+++ b/tests/test_cors_config.py
@@ -5,7 +5,9 @@ import pytest
 from fastapi.testclient import TestClient
 
 # Set ENV to production before importing backend.main to ensure production CORS settings are used
+# Also set POSTGRES_DSN to a dummy value to pass the production config check
 os.environ["ENV"] = "production"
+os.environ["POSTGRES_DSN"] = "postgresql://user:pass@localhost:5432/db"
 
 try:
     from backend.main import app


### PR DESCRIPTION
The user reported a CORS error for 'https://query-craft-frontend-758178119666.us-central1.run.app'. Although this origin was covered by the regex and the list, we explicitly re-added it to the list to ensure no subtle issues (e.g. invisible characters) and to force a redeployment of the backend service to ensure the latest configuration is active. Verified with local reproduction script and existing tests.

---
*PR created automatically by Jules for task [16649199408041380953](https://jules.google.com/task/16649199408041380953) started by @KnellBalm*

## Summary by Sourcery

Bug Fixes:
- Ensure the reported Cloud Run frontend origin is explicitly allowed in the CORS origin whitelist to prevent CORS errors.