### PR TITLE
Fix CORS error for query-craft-frontend-758178119666

### DIFF
--- a/tests/test_cors_config.py
+++ b/tests/test_cors_config.py
@@ -2,27 +2,41 @@
 import os
 import sys
 import pytest
+from unittest import mock
+import importlib
 from fastapi.testclient import TestClient
 
-# Set ENV to production before importing backend.main to ensure production CORS settings are used
-os.environ["ENV"] = "production"
+@pytest.fixture
+def production_app():
+    """Fixture that forces ENV='production' and reloads backend.main app."""
+    # Use mock.patch.dict to temporarily change os.environ
+    with mock.patch.dict(os.environ, {"ENV": "production", "POSTGRES_DSN": "postgresql://mock_user:mock_pass@localhost:5432/mock_db"}):
+        # We need to reload backend.main because the app is created at module level based on ENV
+        if 'backend.main' in sys.modules:
+            import backend.main
+            importlib.reload(backend.main)
+        else:
+            import backend.main
 
-try:
-    from backend.main import app
-except ImportError:
-    sys.path.append(os.getcwd())
-    from backend.main import app
+        yield backend.main.app
+
+    # Cleanup: reload backend.main with original environment (if needed by other tests)
+    # Note: Since pytest runs tests in a single process, reloading here is good practice
+    # to restore the state for subsequent tests.
+    if 'backend.main' in sys.modules:
+        import backend.main
+        importlib.reload(backend.main)
 
 class TestCORSConfig:
     """Test CORS configuration for the backend."""
 
-    def test_cors_specific_origin_allowed(self):
+    def test_cors_specific_origin_allowed(self, production_app):
         """
         Verify that the specific frontend origin reported in the issue is allowed.
         Origin: https://query-craft-frontend-758178119666.us-central1.run.app
         """
         origin = "https://query-craft-frontend-758178119666.us-central1.run.app"
-        client = TestClient(app)
+        client = TestClient(production_app)
 
         # 1. Test Preflight (OPTIONS)
         response = client.options(
@@ -46,10 +60,10 @@ class TestCORSConfig:
         assert response.headers.get("access-control-allow-origin") == origin
         assert response.headers.get("access-control-allow-credentials") == "true"
 
-    def test_cors_cloud_run_domain_regex(self):
+    def test_cors_cloud_run_domain_regex(self, production_app):
         """Verify that other Cloud Run domains matching the regex are also allowed."""
         origin = "https://query-craft-frontend-random-hash.a.run.app"
-        client = TestClient(app)
+        client = TestClient(production_app)
 
         response = client.options(
             "/auth/me",
@@ -61,10 +75,10 @@ class TestCORSConfig:
         assert response.status_code == 200
         assert response.headers.get("access-control-allow-origin") == origin
 
-    def test_cors_disallowed_origin(self):
+    def test_cors_disallowed_origin(self, production_app):
         """Verify that a random origin is NOT allowed."""
         origin = "https://evil-site.com"
-        client = TestClient(app)
+        client = TestClient(production_app)
 
         response = client.options(
             "/auth/me",
@@ -81,13 +95,13 @@ class TestCORSConfig:
 
         assert "access-control-allow-origin" not in response.headers
 
-    def test_path_rewrite_does_not_break_cors(self):
+    def test_path_rewrite_does_not_break_cors(self, production_app):
         """
         Verify that PathRewriteMiddleware (which rewrites /auth/me to /api/auth/me)
         does not interfere with CORS headers.
         """
         origin = "https://query-craft-frontend-758178119666.us-central1.run.app"
-        client = TestClient(app)
+        client = TestClient(production_app)
 
         # Send request to /auth/me (rewritten to /api/auth/me)
         response = client.get(


### PR DESCRIPTION
This PR addresses the CORS policy error reported for `https://query-craft-frontend-758178119666.us-central1.run.app`.

Changes:
1.  **Moved CORS Variables**: Moved `cloud_origins` and `cloud_origin_regex` to the top of `backend/main.py` (before `lifespan`) to ensure they are properly defined and initialized.
2.  **Verified Origin**: Confirmed and ensured the specific failing origin is present in the `cloud_origins` list.
3.  **Added Debugging Middleware**: Added `CORSLoggingMiddleware` in `backend/common/middleware.py` and registered it as the outermost middleware in `backend/main.py`. This middleware logs a warning if a request has an `Origin` header but the response lacks the `Access-Control-Allow-Origin` header, aiding in future debugging.

Verified with `tests/test_cors_config.py`.

---
*PR created automatically by Jules for task [11874747566118330029](https://jules.google.com/task/11874747566118330029) started by @KnellBalm*

## Summary by Sourcery

Resolve CORS header issues for Cloud Run frontend origins and add logging to diagnose future CORS problems.

Bug Fixes:
- Ensure Cloud Run frontend origins, including the previously failing domain, are correctly recognized by the CORS configuration.

Enhancements:
- Introduce CORS logging middleware to detect and log requests with an Origin header that do not receive Access-Control-Allow-Origin in the response.