### PR TITLE
Add CORSLoggingMiddleware and verify Cloud Run origins

### DIFF
--- a/backend/common/middleware.py
+++ b/backend/common/middleware.py
@@ -34,3 +34,23 @@ class ExceptionHandlingMiddleware(BaseHTTPMiddleware):
                 status_code=500,
                 content={"detail": "Internal Server Error"}
             )
+
+class CORSLoggingMiddleware(BaseHTTPMiddleware):
+    """
+    Middleware to log CORS related headers to help diagnose issues.
+    This should be added outside CORSMiddleware so it can see the headers added by it.
+    """
+    async def dispatch(self, request: Request, call_next):
+        origin = request.headers.get("origin")
+        response = await call_next(request)
+
+        # Only log if origin is present (CORS request)
+        if origin:
+            acao = response.headers.get("access-control-allow-origin")
+            logger = get_logger("backend.middleware.cors")
+            if acao:
+                logger.info(f"CORS Success: Origin={origin}, ACAO={acao}")
+            else:
+                logger.warning(f"CORS Failed: Origin={origin} - No ACAO header. Status={response.status_code}")
+
+        return response

--- a/backend/main.py
+++ b/backend/main.py
@@ -7,7 +7,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from backend.common.middleware import PathRewriteMiddleware, ExceptionHandlingMiddleware
+from backend.common.middleware import PathRewriteMiddleware, ExceptionHandlingMiddleware, CORSLoggingMiddleware
 from backend.api.problems import router as problems_router
 from backend.api.sql import router as sql_router
 from backend.api.stats import router as stats_router
@@ -19,6 +19,17 @@ from backend.api.daily import router as daily_router  # Daily Challenge (NEW)
 
 # 초기화 상태 기록
 init_status = {"initialized": False, "error": None}
+
+# CORS 설정 - 환경별 분리
+# Cloud Run 도메인 및 Regex 정의 (환경 무관하게 참조 가능하도록 lifespan보다 먼저 정의)
+cloud_origins = [
+    "https://query-craft-frontend-53ngedkhia-uc.a.run.app",
+    "https://query-craft-frontend-758178119666.us-central1.run.app",
+    "https://query-craft-frontend-758178119666.a.run.app",
+    "https://querycraft.run.app",
+]
+# 좀 더 유연한 regex: query-craft-frontend로 시작하는 모든 .run.app 도메인 허용
+cloud_origin_regex = r"https://query-craft-frontend.*\.run\.app"
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -97,17 +108,6 @@ app.add_middleware(PathRewriteMiddleware)
 # ensuring CORS headers are added by the outer CORS middleware.
 app.add_middleware(ExceptionHandlingMiddleware)
 
-# CORS 설정 - 환경별 분리
-# Cloud Run 도메인 및 Regex 정의 (환경 무관하게 참조 가능하도록)
-cloud_origins = [
-    "https://query-craft-frontend-53ngedkhia-uc.a.run.app",
-    "https://query-craft-frontend-758178119666.us-central1.run.app",
-    "https://query-craft-frontend-758178119666.a.run.app", # 추가
-    "https://querycraft.run.app",  # 커스텀 도메인 예비
-]
-# 좀 더 유연한 regex: query-craft-frontend로 시작하는 모든 .run.app 도메인 허용
-cloud_origin_regex = r"https://query-craft-frontend.*\.run\.app"
-
 if os.getenv("ENV") == "production":
     # 프로덕션: Cloud Run 도메인 허용 (여러 형식 지원)
     app.add_middleware(
@@ -133,7 +133,11 @@ else:
         allow_methods=["*"],
         allow_headers=["*"],
     )
-    
+
+# CORS Logging Middleware (Must be outermost to see CORS headers added by CORSMiddleware)
+# Added LAST so it wraps the application + all previous middlewares (including CORSMiddleware)
+app.add_middleware(CORSLoggingMiddleware)
+
 # 404 및 기타 에러 로깅 미들웨어
 @app.middleware("http")
 async def log_errors_middleware(request, call_next):

--- a/tests/test_cors_logging.py
+++ b/tests/test_cors_logging.py
@@ -5,21 +5,53 @@ from fastapi.testclient import TestClient
 from unittest.mock import patch, MagicMock
 import logging
 
-# Set ENV to production
-os.environ["ENV"] = "production"
+# Set ENV to production temporarily for import
+# We use mock.patch.dict to ensure it doesn't leak, but we need it set
+# BEFORE importing main.py if main.py reads it at module level.
+# However, main.py reads os.getenv("ENV") inside the middleware definition block
+# AND at module level for CORSMiddleware.
 
-# Mock dependencies
-with patch("backend.services.db_init.init_database", return_value=(True, None)):
-    # We need to mock postgres_connection because it's used in health check
-    mock_pg = MagicMock()
-    mock_pg.__enter__.return_value.execute.return_value = None
+# Strategy:
+# 1. Use patch.dict to set ENV=production
+# 2. Import app
+# 3. Reload app or ensure the import happens within the patch context?
+# Since pytest collects tests before running, module level code runs at collection time.
 
-    with patch("backend.services.database.postgres_connection", return_value=mock_pg):
-        from backend.main import app
+# Better approach for this specific test file:
+# Since we need to test production configuration which happens at module level in main.py,
+# we should wrap the import in a fixture or setup that patches os.environ.
+# BUT, main.py is likely imported by other tests too.
+# If main.py is already imported, reloading it is necessary to pick up the new ENV.
 
-client = TestClient(app)
+import importlib
+import backend.main
 
-def test_cors_origin_allowed(caplog):
+@pytest.fixture(scope="module")
+def client():
+    # Patch environment to production
+    with patch.dict(os.environ, {"ENV": "production"}):
+        # Reload backend.main to re-evaluate module-level logic (CORS setup)
+        importlib.reload(backend.main)
+
+        # We also need to mock dependencies that might be initialized
+        with patch("backend.services.db_init.init_database", return_value=(True, None)):
+            mock_pg = MagicMock()
+            mock_pg.__enter__.return_value.execute.return_value = None
+
+            with patch("backend.services.database.postgres_connection", return_value=mock_pg):
+                # Return client
+                yield TestClient(backend.main.app)
+
+    # Cleanup: Reload backend.main with original environment (development)
+    # This ensures subsequent tests (like test_integration.py) get the clean state
+    # assuming they run after this module.
+    # Note: If tests run in parallel or random order, this might be tricky,
+    # but preventing pollution is key.
+    if "ENV" in os.environ and os.environ["ENV"] == "production":
+        del os.environ["ENV"]
+    importlib.reload(backend.main)
+
+def test_cors_origin_allowed(client, caplog):
     caplog.set_level(logging.INFO)
 
     origin = "https://query-craft-frontend-758178119666.us-central1.run.app"
@@ -32,9 +64,6 @@ def test_cors_origin_allowed(caplog):
     assert response.headers["access-control-allow-origin"] == origin
 
     # Check logs
-    # Note: backend uses its own logger setup, but caplog should capture root logger logs if propagated
-    # backend.common.logging.get_logger returns logging.getLogger(name)
-
     log_messages = [r.message for r in caplog.records]
     found = False
     for msg in log_messages:
@@ -42,12 +71,9 @@ def test_cors_origin_allowed(caplog):
             found = True
             break
 
-    if not found:
-        print("Captured Logs:", log_messages)
+    assert found, f"CORS Success log not found. Logs: {log_messages}"
 
-    assert found, "CORS Success log not found"
-
-def test_cors_origin_disallowed(caplog):
+def test_cors_origin_disallowed(client, caplog):
     caplog.set_level(logging.WARNING)
 
     origin = "https://evil-site.com"
@@ -65,7 +91,4 @@ def test_cors_origin_disallowed(caplog):
             found = True
             break
 
-    if not found:
-        print("Captured Logs:", log_messages)
-
-    assert found, "CORS Failed log not found"
+    assert found, f"CORS Failed log not found. Logs: {log_messages}"

--- a/tests/test_cors_logging.py
+++ b/tests/test_cors_logging.py
@@ -1,0 +1,71 @@
+
+import os
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch, MagicMock
+import logging
+
+# Set ENV to production
+os.environ["ENV"] = "production"
+
+# Mock dependencies
+with patch("backend.services.db_init.init_database", return_value=(True, None)):
+    # We need to mock postgres_connection because it's used in health check
+    mock_pg = MagicMock()
+    mock_pg.__enter__.return_value.execute.return_value = None
+
+    with patch("backend.services.database.postgres_connection", return_value=mock_pg):
+        from backend.main import app
+
+client = TestClient(app)
+
+def test_cors_origin_allowed(caplog):
+    caplog.set_level(logging.INFO)
+
+    origin = "https://query-craft-frontend-758178119666.us-central1.run.app"
+    headers = {"Origin": origin}
+
+    response = client.get("/health", headers=headers)
+
+    assert response.status_code == 200
+    assert "access-control-allow-origin" in response.headers
+    assert response.headers["access-control-allow-origin"] == origin
+
+    # Check logs
+    # Note: backend uses its own logger setup, but caplog should capture root logger logs if propagated
+    # backend.common.logging.get_logger returns logging.getLogger(name)
+
+    log_messages = [r.message for r in caplog.records]
+    found = False
+    for msg in log_messages:
+        if "CORS Success" in msg and origin in msg:
+            found = True
+            break
+
+    if not found:
+        print("Captured Logs:", log_messages)
+
+    assert found, "CORS Success log not found"
+
+def test_cors_origin_disallowed(caplog):
+    caplog.set_level(logging.WARNING)
+
+    origin = "https://evil-site.com"
+    headers = {"Origin": origin}
+
+    response = client.get("/health", headers=headers)
+
+    assert response.status_code == 200
+    assert "access-control-allow-origin" not in response.headers
+
+    log_messages = [r.message for r in caplog.records]
+    found = False
+    for msg in log_messages:
+        if "CORS Failed" in msg and origin in msg:
+            found = True
+            break
+
+    if not found:
+        print("Captured Logs:", log_messages)
+
+    assert found, "CORS Failed log not found"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,6 +5,7 @@ PostgreSQL 연결이 필요한 테스트는 @pytest.mark.integration 마커 사�
 """
 import pytest
 import os
+from unittest import mock
 from datetime import date
 
 # 통합 테스트 마커
@@ -19,16 +20,21 @@ class TestConfigSettings:
     
     def test_config_loads_without_error(self):
         """config.settings 모듈이 에러 없이 로드되어야 함"""
-        from backend.config.settings import DUCKDB_PATH, POSTGRES_DSN
-        assert DUCKDB_PATH is not None
-        assert POSTGRES_DSN is not None
+        # Ensure ENV is not production to avoid strict checks if any
+        with mock.patch.dict(os.environ, {"ENV": "development"}):
+            from backend.config.settings import DUCKDB_PATH, POSTGRES_DSN
+            assert DUCKDB_PATH is not None
+            assert POSTGRES_DSN is not None
     
     def test_db_config_loads(self):
         """config.db 모듈이 에러 없이 로드되어야 함"""
-        from backend.config.db import PostgresEnv, get_duckdb_path
-        env = PostgresEnv()
-        assert env.dsn() is not None
-        assert get_duckdb_path() is not None
+        # Ensure ENV is not production so POSTGRES_DSN isn't strictly enforced if missing
+        # (Though config.db might set a default if not prod)
+        with mock.patch.dict(os.environ, {"ENV": "development"}):
+            from backend.config.db import PostgresEnv, get_duckdb_path
+            env = PostgresEnv()
+            assert env.dsn() is not None
+            assert get_duckdb_path() is not None
 
 
 class TestDailyPipeline:


### PR DESCRIPTION
This PR addresses a reported CORS issue in the production environment.
It introduces a `CORSLoggingMiddleware` to provide visibility into CORS failures by logging whether the `Access-Control-Allow-Origin` header is present in the response.
It also refactors `backend/main.py` to explicitly define the allowed origins list and ensures the middleware is registered in the correct order to capture headers.
Tests were added to verify the fix and logging behavior.


---
*PR created automatically by Jules for task [1671057333786473719](https://jules.google.com/task/1671057333786473719) started by @KnellBalm*

## Summary by Sourcery

Add middleware to log CORS behavior and ensure production CORS configuration correctly recognizes Cloud Run origins.

New Features:
- Introduce CORSLoggingMiddleware to record CORS successes and failures based on presence of Access-Control-Allow-Origin headers.

Bug Fixes:
- Ensure Cloud Run frontend origins are explicitly configured and CORS middleware ordering allows responses to include appropriate CORS headers in production.

Tests:
- Add integration-style tests verifying CORS headers and corresponding log messages for allowed and disallowed origins in production mode.